### PR TITLE
🐛 fix: #125 Set author and assignee columns to show full width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -335,6 +335,10 @@ table.github-link-table {
 	align-items: center;
 }
 
+.github-link-table-author {
+	width: max-content;
+}
+
 .github-link-table-labels {
 	height: 100%;
 	flex-wrap: wrap;


### PR DESCRIPTION
Closes: #125
