### PR TITLE
Improve inline link style

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -176,6 +176,14 @@ body.theme-dark {
 	overflow: hidden;
 }
 
+.github-link-inline-section:first-child {
+	border-radius: 3.5px 0 0 3.5px;
+}
+
+.github-link-inline-section:last-child {
+	border-radius: 0 3.5px 3.5px 0;
+}
+
 .github-link-inline-icon {
 	display: inline-flex;
 	padding: 2px 0;


### PR DESCRIPTION
Inline links are rounded, with this plugin - 4px radius. The sections of those links don't have rounded corners, which causes their borders to be clipped. This rounds the sections inside to make them look smoother.

Before:

![CleanShot 2024-09-09 at 17 35 24@2x](https://github.com/user-attachments/assets/ef7c4da4-e942-4421-9bce-655af186ab9b)

After:

![CleanShot 2024-09-09 at 17 35 08@2x](https://github.com/user-attachments/assets/79f079d2-4e30-4406-9ef9-c583c07a2acd)
