### PR TITLE
Feature/yaml-query

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ Github links are automatically transformed into tags. For example, pasting `http
 
 You can also include a table with results from a search query using a `github-query` codeblock. For example:
 
-````
+~~~yaml
 ```github-query
 outputType: table
 queryType: pull-request
-query: "is:pr repo:nathonius/obsidian-github-link"
+query:
+  repo: nathonius/obsidian-github-link
 columns: [number, title, author, status]
 ```
-````
+~~~
 
 This produces a table of results that refreshes upon opening the note.
 

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -3,7 +3,7 @@ import { RequestError, mapObject } from "../util";
 import type { GithubAccount } from "../settings";
 import { PluginSettings } from "../plugin";
 import { issueListSortFromQuery, pullListSortFromQuery, searchSortFromQuery } from "../query/sort";
-import type { QueryParams } from "../query/types";
+import { type QueryParams, QueryType } from "../query/types";
 import { GitHubApi } from "./api";
 import type {
 	CheckRunListResponse,
@@ -22,7 +22,7 @@ import type {
 
 // TODO: Refactor this whole file into a class for better use in dataview queries, etc
 
-const tokenMatchRegex = /repo:(.+)\//;
+const tokenMatchRegex = /repo:([\w\-]+)\//;
 const api = new GitHubApi();
 
 function getAccount(org?: string): GithubAccount | undefined {
@@ -148,17 +148,38 @@ export function listCheckRunsForRef(
 	return api.listCheckRunsForRef(org, repo, ref, getToken(org), skipCache);
 }
 
+function appendFilter(query: string, [qualifier, value]: [string, string]): string {
+	value = value.trim();
+	// spaces need wrapped in quotes like `reason:"not planned"`
+	if (value.includes(" ") && !value.includes('"')) {
+		value = `"${value}"`;
+	}
+	return `${query} ${qualifier}:${value}`;
+}
+
+export function serializeQueryParams({ query = "", queryType }: QueryParams): string {
+	if (typeof query !== "string") {
+		// extract optional search term from filter pairs like `state:open`
+		const { search = "", ...filters } = query;
+		query = Object.entries(filters).reduce(appendFilter, search);
+	}
+	query = query.trim();
+	switch (queryType) {
+		case QueryType.Issue: return appendFilter(query, ["type", "issue"]);
+		case QueryType.PullRequest: return appendFilter(query, ["type", "pr"]);
+		default: throw new Error("Unreachable case: query type not supported");
+	}
+}
+
 export async function searchIssues(
 	params: QueryParams,
-	query: string,
-	org?: string,
 	skipCache = false,
 ): Promise<MaybePaginated<IssueSearchResponse>> {
 	const searchParams = mapObject<QueryParams, IssueSearchParams>(
 		params,
 		{
-			q: () => query,
-			sort: (params) => searchSortFromQuery(params),
+			q: serializeQueryParams,
+			sort: searchSortFromQuery,
 			order: (params) => params.order,
 			page: (params) => params.page,
 			per_page: (params) => params.per_page,
@@ -168,7 +189,7 @@ export async function searchIssues(
 	);
 
 	setPageSize(searchParams);
-	return api.searchIssues(searchParams, getToken(org, query), skipCache);
+	return api.searchIssues(searchParams, getToken(params.org, searchParams.q), skipCache);
 }
 
 // TODO: This is in the wrong place and should be at the API level to be properly cached

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -1,10 +1,11 @@
 import { parseYaml, setIcon } from "obsidian";
 import {
-	searchIssues,
+	getIssuesForOrganization,
 	getIssuesForRepo,
 	getMyIssues,
 	getPullRequestsForRepo,
-	getIssuesForOrganization,
+	searchIssues,
+	serializeQueryParams,
 } from "../github/github";
 import type { MaybePaginated, PaginationMeta } from "../github/response";
 import { PluginSettings } from "../plugin";
@@ -66,7 +67,7 @@ export class GithubQuery {
 		if (params.outputType === OutputType.Table) {
 			// Custom Query
 			if (params.query && (params.queryType === QueryType.Issue || params.queryType === QueryType.PullRequest)) {
-				const { meta, response } = await searchIssues(params, params.query, params.org, skipCache);
+				const { meta, response } = await searchIssues(params, skipCache);
 				return { meta, response: response.items };
 			}
 			// Issue query with org and repo provided
@@ -223,7 +224,8 @@ export class GithubQuery {
 	private getExternalLink(params: QueryParams): string | null {
 		// Custom search query
 		if (params.query && (params.queryType === QueryType.Issue || params.queryType === QueryType.PullRequest)) {
-			return `https://github.com/search?q=${encodeURIComponent(params.query)}`;
+			const query = serializeQueryParams(params);
+			return `https://github.com/search?q=${encodeURIComponent(query)}`;
 		} else {
 			return null;
 		}

--- a/src/query/types.ts
+++ b/src/query/types.ts
@@ -27,7 +27,7 @@ export interface QueryParams {
 	/**
 	 * Custom query. This will override most other options.
 	 */
-	query?: string;
+	query?: string | Record<string, string>;
 
 	/**
 	 * Pagination page size


### PR DESCRIPTION
Enables writing custom queries using YAML blocks instead instead of strings.

Before:

```yaml
outputType: table
queryType: pull-request
query: 'type:pr state:open author:texastoland'
```

Or:

```yaml
outputType: table
queryType: pull-request
query: >-
  type:pr
  state:open
  author:texastoland
```

After:

```yaml
outputType: table
queryType: pull-request
query:
  state: open
  author: texastoland
```


Confirmed working by adding https://github.com/texastoland/obsidian-github-link to [BRAT](https://obsidian.md/plugins?id=obsidian42-brat). 🚀